### PR TITLE
Reading of more types of recipes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.eol": "\n",
+    "files.insertFinalNewline": true,
+    "files.trimFinalNewlines": true
+}

--- a/crafting_combinator/changelog.txt
+++ b/crafting_combinator/changelog.txt
@@ -1,4 +1,11 @@
 ---------------------------------------------------------------------------------------------------
+Version: 0.17.0
+Date: 11. 23. 2021
+  Features:
+    - Crafting combinator can now read and output ingredients of set recipe (new setting)
+    - Crafting combinator can now read from rocket silos
+    - Crafting combinator can now read product and ingredients for machines that have fixed (static) recipes (like a rocket silo and modded assemblers)
+---------------------------------------------------------------------------------------------------
 Version: 0.16.3
 Date: 11. 12. 2021
   Changes:

--- a/crafting_combinator/config.lua
+++ b/crafting_combinator/config.lua
@@ -23,6 +23,7 @@ return {
 		read_recipe = true,
 		read_speed = false,
 		read_bottleneck = false,
+		read_ingredients = false,
 	},
 	RC_DEFAULT_SETTINGS = {
 		mode = 'ing',

--- a/crafting_combinator/data.lua
+++ b/crafting_combinator/data.lua
@@ -8,7 +8,7 @@ local cc = table.deepcopy(data.raw['constant-combinator']['constant-combinator']
 cc.name = config.CC_NAME
 cc.icon = '__crafting_combinator__/graphics/icon-crafting-combinator.png'
 cc.icon_size = 32
-cc.item_slot_count = 3
+cc.item_slot_count = 255
 cc.minable.result = cc.name
 table.insert(cc.flags, 'not-deconstructable')
 

--- a/crafting_combinator/info.json
+++ b/crafting_combinator/info.json
@@ -1,9 +1,9 @@
 {
 	"name": "crafting_combinator",
-	"version": "0.16.3",
+	"version": "0.17.0",
 	"factorio_version": "1.1",
 	"title": "Crafting Combinator",
-	"author": "LuziferSenpai and TheRustyKnife",
+	"author": "LuziferSenpai, TheRustyKnife, MarximusMaximus",
 	"description": "Includes combinators that allow you to set or read the recipe of any crafting machine, get ingredients or products of a recipe and more!",
 	"dependencies": ["base", "rusty-locale"]
 }

--- a/crafting_combinator/locale/cs/cs.cfg
+++ b/crafting_combinator/locale/cs/cs.cfg
@@ -52,6 +52,7 @@ empty-inserters=Vyprazdňovat překladače (zamezuje zasekávání)
 read-recipe=Číst aktuální recept
 read-speed=Číst rychlost výrobny
 read-machine-status=Číst status výrobny
+read-ingredients=Číst ingredience výrobny
 multiply-by-input=Vynásobit výsledky vstupní hodnotou
 multiply-by-input:tooltip=Každý výstupní signál bude před nastavením na výstup vynásoben hodnotou vybraného vstupního signálu
 divide-by-output=Vydělit výsledky počtem produktu/ingredience

--- a/crafting_combinator/locale/de/de.cfg
+++ b/crafting_combinator/locale/de/de.cfg
@@ -46,6 +46,7 @@ discard-fluids=Flüssigkeiten verwerfen
 empty-inserters=Greifer leeren (verhindert Blockierungen)
 read-speed=Herstellungsgeschwindigkeit auslesen
 read-machine-status=Status auslesen
+read-ingredients=Zutaten auslesen
 multiply-by-input=Ergebnisse mit der Einganssignalstärke multiplizieren
 multiply-by-input:tooltip=Mulpiziert jedes Signal mit der Signalstärke des ausgewählten Einganssignals bevor es ausgegeben wird
 divide-by-output=Ergebnisse durch die Menge im Rezept teilen

--- a/crafting_combinator/locale/en/en.cfg
+++ b/crafting_combinator/locale/en/en.cfg
@@ -56,6 +56,7 @@ empty-inserters=Empty inserters' hands (prevents jamming)
 read-recipe=Read the current recipe
 read-speed=Read the machine's crafting speed
 read-machine-status=Read machine status
+read-ingredients=Read ingredients
 multiply-by-input=Multiply results by input count
 multiply-by-input:tooltip=Take each resulting signal and multiply it by the strength of the chosen input signal before outputting it
 divide-by-output=Divide results by product/ingredient count

--- a/crafting_combinator/migrations/0.17.0.lua
+++ b/crafting_combinator/migrations/0.17.0.lua
@@ -1,0 +1,11 @@
+if not late_migrations then return end
+
+local config = require 'config'
+local cc_control = require 'script.cc'
+local settings_parser = require 'script.settings-parser'
+
+
+log("Adding missing settings to combinators...")
+for _, combinator in pairs(global.cc.data) do
+	settings_parser.fill_defaults(combinator.settings, config.CC_DEFAULT_SETTINGS)
+end

--- a/crafting_combinator/script/cc.lua
+++ b/crafting_combinator/script/cc.lua
@@ -39,6 +39,7 @@ _M.settings_parser = settings_parser {
 	read_speed = {'s', 'bool'},
 	read_machine_status = {'st', 'bool'},
 	wait_for_output_to_clear = {'wo', 'bool'},
+	read_ingredients = {'ing', 'bool'},
 }
 
 
@@ -194,6 +195,7 @@ function _M:update()
 			if self.settings.read_recipe then self:read_recipe(params); end
 			if self.settings.read_speed then self:read_speed(params); end
 			if self.settings.read_machine_status then self:read_machine_status(params); end
+			if self.settings.read_ingredients then self:read_ingredients(params); end
 		end
 	end
 	
@@ -223,6 +225,7 @@ function _M:open(player_index)
 			gui.checkbox('read-recipe', self.settings.read_recipe),
 			gui.checkbox('read-speed', self.settings.read_speed),
 			gui.checkbox('read-machine-status', self.settings.read_machine_status),
+			gui.checkbox('read-ingredients', self.settings.read_ingredients),
 		}
 	}):open(player_index)
 	
@@ -259,6 +262,7 @@ function _M:update_disabled_checkboxes(root)
 	self:disable_checkbox(root, 'misc:read-recipe', 'r')
 	self:disable_checkbox(root, 'misc:read-speed', 'r')
 	self:disable_checkbox(root, 'misc:read-machine-status', 'r')
+	self:disable_checkbox(root, 'misc:read-ingredients', 'r')
 end
 
 function _M:disable_checkbox(root, name, mode)
@@ -311,6 +315,21 @@ function _M:read_machine_status(params)
 		count = 1,
 		index = 3,
 	})
+end
+
+function _M:read_ingredients(params)
+	local recipe = self.assembler.get_recipe()
+	if recipe then
+        local append_index = 4
+		for k, v in pairs(recipe.ingredients) do
+			table.insert(params, {
+				signal = recipe_selector.get_signal(v.name),
+				count = v.amount,
+                index = append_index,
+			})
+			append_index = append_index + 1
+		end
+	end
 end
 
 function _M:set_recipe()
@@ -496,9 +515,9 @@ end
 function _M:find_assembler(assembler_to_ignore)
 	self.assembler = self.entity.surface.find_entities_filtered {
 		position = util.position(self.entity.position):shift(self.entity.direction, config.ASSEMBLER_DISTANCE),
-		type = 'assembling-machine',
-	}[1]
-	if self.assembler and (self.assembler == assembler_to_ignore or self.assembler.prototype.fixed_recipe) then
+		type = {'assembling-machine', 'rocket-silo'},
+	}[1] 
+	if self.assembler and (self.assembler == assembler_to_ignore) then
 		self.assembler = nil
 	end
 	


### PR DESCRIPTION
    - Crafting combinator can now read and output ingredients of set recipe (new setting)
    - Crafting combinator can now read from rocket silos
    - Crafting combinator can now read product and ingredients for machines that have fixed (static) recipes (like a rocket silo and modded assemblers)

also add VSCode settings to keep files and line endings correct/consistent across platforms